### PR TITLE
Fix smooth checkbox and stop referencing removed fields

### DIFF
--- a/W_Capsule.py
+++ b/W_Capsule.py
@@ -222,9 +222,9 @@ class Make_WCapsule(bpy.types.Operator):
         wD.smo = self.smoothed
         wD.wType = 'WCAPSULE'
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Cone.py
+++ b/W_Cone.py
@@ -221,9 +221,9 @@ class Make_WCone(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Cone.py
+++ b/W_Cone.py
@@ -218,11 +218,8 @@ class Make_WCone(bpy.types.Operator):
 
         mesh.from_pydata(*update_WCone(wD))
         mesh.update()
-        
-        object_utils.object_data_add(context, mesh, operator=None)
 
-        if self.smoothed:
-            bpy.ops.object.shade_smooth()
+        object_utils.object_data_add(context, mesh, operator=None)
 
         return {'FINISHED'}
 

--- a/W_Ring.py
+++ b/W_Ring.py
@@ -206,8 +206,9 @@ class Make_WRing(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Ring.py
+++ b/W_Ring.py
@@ -203,11 +203,8 @@ class Make_WRing(bpy.types.Operator):
 
         mesh.from_pydata(*update_WRing(wD))
         mesh.update()
-        
-        object_utils.object_data_add(context, mesh, operator=None)
 
-        if self.smoothed:
-            bpy.ops.object.shade_smooth()
+        object_utils.object_data_add(context, mesh, operator=None)
 
         return {'FINISHED'}
 

--- a/W_Screw.py
+++ b/W_Screw.py
@@ -290,9 +290,9 @@ class Make_WScrew(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Sphere.py
+++ b/W_Sphere.py
@@ -217,9 +217,9 @@ class Make_WSphere(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Torus.py
+++ b/W_Torus.py
@@ -196,9 +196,9 @@ class Make_WTorus(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel

--- a/W_Tube.py
+++ b/W_Tube.py
@@ -379,9 +379,9 @@ class Make_WTube(bpy.types.Operator):
         
         object_utils.object_data_add(context, mesh, operator=None)
 
-        bpy.ops.object.shade_smooth()
-        context.object.data.use_auto_smooth = True
-        context.object.data.auto_smooth_angle = 1.0
+        if self.smoothed:
+            bpy.ops.object.shade_smooth()
+
         return {'FINISHED'}
 
 # create UI panel


### PR DESCRIPTION
auto smooth was removed, so creating a mesh causes a python error. i have fixed that.

also, smoothing wasn't linked to the smooth checkbox in the first place, so i added that as well